### PR TITLE
Imageutils

### DIFF
--- a/research/configs/visdom.yaml
+++ b/research/configs/visdom.yaml
@@ -1,0 +1,8 @@
+port: 8000
+x_min: -1
+x_max: 1
+y_min: -1
+y_max: 1
+env_name: "main"
+log_to_filename: "new"
+offline: True

--- a/research/utils/image_utils.py
+++ b/research/utils/image_utils.py
@@ -161,12 +161,19 @@ def affine_transform(
     rotate=True,
 ) -> torch.Tensor:
     """Input arguments:
+    SUPER IMPORTANT FOR IMG TO BE CHANNEL FIRST COS AFFINE_GRID 
+    WILL DO ITS THINGREGARLDESS WITHOUT THROWING AN ERROR
     img: b x c x w x h tensor or c x w x h tensor
     affine_matrices: 2x3 tensor
     Returns: transformed_img: bxcxwxh"""
 
     if len(img.shape) == 3:
         img = torch.unsqueeze(img, dim=0)
+
+    try:
+        assert img.shape[2] == img.shape[3]
+    except AssertionError:
+        raise Exception("img not channel first")
 
     grid = F.affine_grid(affine_matrices, list(img.shape))
     transformed_image = F.grid_sample(img, grid, mode="bilinear")
@@ -371,28 +378,27 @@ def low_passed_image(
 
 if __name__ == "__main__":
 
-    gpu = 0
+    """gpu = 0
     img_resized = read_image_resize("../dummy_data/dog_boat_bird.png", (224, 224))
     img_resized = torch.tensor(convert_whc_to_cwh(img_resized)).cuda()
     threshold = torch.tensor([10])
-    low_img = low_passed_image(img_resized, threshold, True)
+    low_img = low_passed_image(img_resized, threshold, True)"""
 
-    """
     gpu = 0
-    img_resized = read_image_resize("../dummy_data/dog_boat_bird.png", (224,224))
-    img_resized = np.expand_dims(img_resized,axis=0)
-    img_resized = torch.tensor(convert_whc_to_cwh(img_resized)).cuda()
+    img_resized = read_image_resize("../dummy_data/dog_boat_bird.png", (224, 224))
+    img_resized = np.expand_dims(img_resized, axis=0)
+    img_resized = torch.tensor(img_resized).cuda()
     threshold = torch.tensor([10])
-    low_img = low_passed_image(img_resized, threshold, True)
-    img_resized_normal = normalize(img_resized)
+    # low_img = low_passed_image(img_resized, threshold, True)
+    # img_resized_normal = normalize(img_resized)
 
     thedx = torch.tensor([1.0]).cuda()
     thedy = torch.tensor([1.0]).cuda()
     scale = torch.tensor([1.0]).cuda()
 
-    the_matrix = create_M_matrix(thedx,thedy,scale)
-    
+    the_matrix = create_M_matrix(thedx, thedy, scale)
+
     output = affine_transform(img_resized, the_matrix)
-    
+
     current = convert_cwh_to_whc(output.detach().cpu().numpy())
-    plt.imsave("lol.png",current[0])"""
+    plt.imsave("lol.png", current[0])

--- a/research/utils/visdom_utils.py
+++ b/research/utils/visdom_utils.py
@@ -1,0 +1,94 @@
+import numpy as np
+
+import os
+import time
+import random
+
+import cv2
+from visdom import Visdom
+from visdom import server
+from torchvision.transforms import ToTensor
+from torch import Tensor
+import matplotlib.pyplot as plt
+import matplotlib
+import pdb
+import signal
+import hydra
+
+
+matplotlib.use("tkagg")
+
+
+@hydra.main(config_path="configs/visdom.yaml")
+def make_visdom(cfg):
+    vdb = Visualizer(cfg)
+
+
+class Visualizer:
+    def init(self, cfg):
+
+        self.visdom_config = cfg
+        visdom_command = (
+            "screen -S visdom_"
+            + str(visdom_config["port"])
+            + ' -d -m bash -c "python -m visdom.server -port '
+            + str(visdom_config["port"])
+            + '"'
+        )
+        os.system(visdom_command)
+        time.sleep(2)
+        self.env = cfg.env_name
+        self.vis = visdom.Visdom(
+            port=cfg.port,
+            log_to_filename="temp/" + cfg.log_to_filename,
+            offline=cfg.offline,
+        )
+        (self.x_min, self.x_max), (self.y_min, self.y_max) = (
+            (cfg.x_min, cfg.x_max),
+            (cfg.y_min, cfg.y_max),
+        )
+        self.counter = 0
+        self.plots = {}
+
+    def img_result(self, img_list, nrow, caption="view", title="title", win=1):
+        self.vis.images(
+            img_list, nrow=nrow, win=win, opts={"caption": caption, "title": title}
+        )
+
+    def plot_img_255(self, img, caption="view", title="view", win=1):
+        self.vis.image(img, win=win, opts={"caption": caption, "title": title})
+
+    def plot_matplotlib(self, fig, caption="view", title="title", win=1):
+        self.vis.matplot(
+            fig, win=win, opts={"caption": caption, "title": title, "resizable": True}
+        )
+
+    def plot_plotly(self, fig, caption="view", title="title", win=1):
+        self.vis.plotlyplot(fig, win=win)
+
+    def plot(self, var_name, split_name, title_name, x, y):
+        if var_name not in self.plots:
+            self.plots[var_name] = self.vis.line(
+                X=np.array([x, x]),
+                Y=np.array([y, y]),
+                env=self.env,
+                opts=dict(
+                    legend=[split_name],
+                    title=title_name,
+                    xlabel="Epochs",
+                    ylabel=var_name,
+                ),
+            )
+        else:
+            self.vis.line(
+                X=np.array([x]),
+                Y=np.array([y]),
+                env=self.env,
+                win=self.plots[var_name],
+                name=split_name,
+                update="append",
+            )
+
+
+if __name__ == "__main__":
+    make_visdom()


### PR DESCRIPTION
Added an assertion error for my affine_transform function. Its crazy -- torch affine_grid will take an affine matrix M, and crop it without throwing any error regardless of whether you pass in a cxwxh or a wxhxc image, and  ofcourse the crops are different. Super easy to make this bug/mistake, though the docs say it should take a cxwxh image there are not checks for this. Not used to writing assertions errors, so just make sure I did it in the standard practice way of doing it pls. 