### PR TITLE
huge commit of the regression demo + vector_to_visdom + multiple line…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Hydra Experiment Logging
-outputs
+**/outputs
+**/multirun
 
 # data
 data

--- a/research/configs/backbone/resnet50.yaml
+++ b/research/configs/backbone/resnet50.yaml
@@ -1,2 +1,3 @@
 backbone:
   backbone_name: resnet50
+  learning_rate: 0.01

--- a/research/configs/backbone/vgg19.yaml
+++ b/research/configs/backbone/vgg19.yaml
@@ -1,2 +1,3 @@
 backbone:
   backbone_name: vgg19
+  learning_rate: 0.01

--- a/research/configs/default.yaml
+++ b/research/configs/default.yaml
@@ -4,6 +4,7 @@ defaults:
 
 # Directories
 dirs:
+  runtime_cwd: ${hydra:runtime.cwd}
   data: ./data
 
 # Files
@@ -14,12 +15,13 @@ random_seed: 26
 data_loader_workers: 4
 
 example: classification
-learning_rate: 0.0017
+
 
 mode:
   train:
     batch_size: 64
     max_epochs: 3
+    learning_rate: 0.0017
     shuffle: True
   val:
     batch_size: 64

--- a/research/configs/default.yaml
+++ b/research/configs/default.yaml
@@ -12,6 +12,10 @@ files:
 
 random_seed: 26
 data_loader_workers: 4
+
+example: classification
+learning_rate: 0.0017
+
 mode:
   train:
     batch_size: 64

--- a/research/dataset/__init__.py
+++ b/research/dataset/__init__.py
@@ -9,13 +9,13 @@ from torch.autograd import Variable
 import torch.utils.data as utils_data
 from typing import Tuple
 from torchvision.transforms import Compose, ToTensor, Normalize
-import pandas as pd 
+import pandas as pd
 import numpy as np
 
 
 def get_dataloaders(
-    cfg: DictConfig, num_workers: int = 4,
-dataset_name: str = "mnist") -> Tuple[DataLoader, DataLoader]:
+    cfg: DictConfig, num_workers: int = 4, dataset_name: str = "mnist"
+) -> Tuple[DataLoader, DataLoader]:
     """Return training and validation dataloaders"""
 
     ##################################################################
@@ -47,11 +47,11 @@ dataset_name: str = "mnist") -> Tuple[DataLoader, DataLoader]:
     elif dataset_name == "reunion":
 
         (
-        list_of_training_inputs,
-        training_target_df,
-        list_of_testing_inputs,
-        testing_target_df,
-        ) = process_uni_data()
+            list_of_training_inputs,
+            training_target_df,
+            list_of_testing_inputs,
+            testing_target_df,
+        ) = process_uni_data(cfg)
 
         inputs_train = Variable(torch.FloatTensor(list_of_training_inputs))
         targets_train = Variable(torch.FloatTensor(training_target_df))
@@ -73,16 +73,24 @@ dataset_name: str = "mnist") -> Tuple[DataLoader, DataLoader]:
     return train_dataloader, val_dataloader
 
 
-def get_data_from_csv():
+def get_data_from_csv(cfg: DictConfig):
 
     list_of_dfs = []
     for csv in os.listdir(
-        "../../../../dataset/production_data/Consommation_universite-reunion"
+        os.path.join(
+            cfg.dirs.runtime_cwd,
+            "research/dataset/production_data/Consommation_universite-reunion",
+        )
+        # "research/dataset/production_data/Consommation_universite-reunion"
     ):
 
         df = pd.read_csv(
-            "../../../../dataset/production_data/Consommation_universite-reunion/"
-            + csv,
+            os.path.join(
+                cfg.dirs.runtime_cwd,
+                "research/dataset/production_data/Consommation_universite-reunion",
+                csv,
+            ),
+            # "research/dataset/production_data/Consommation_universite-reunion/" + csv,
             engine="python",
             sep=";",
         )
@@ -113,9 +121,9 @@ def get_data_from_csv():
     return all_data_ten, all_data_ten_avg
 
 
-def process_uni_data():
+def process_uni_data(cfg: DictConfig):
 
-    all_data_ten, all_data_ten_avg = get_data_from_csv()
+    all_data_ten, all_data_ten_avg = get_data_from_csv(cfg)
 
     list_of_input = []
     list_of_output = []
@@ -152,13 +160,9 @@ def process_uni_data():
     training_target_df = target_vals[:541] / 1777.0
     testing_target_df = target_vals[541:] / 1777.0
 
-    
     return (
         training_input_df.reshape(training_input_df.shape[0], -1),
         training_target_df,
         testing_input_df.reshape(testing_input_df.shape[0], -1),
         testing_target_df,
     )
-
-
-

--- a/research/dataset/__init__.py
+++ b/research/dataset/__init__.py
@@ -3,40 +3,72 @@ import os
 import torchvision
 
 from omegaconf import DictConfig
+import torch
 from torch.utils.data import DataLoader
+from torch.autograd import Variable
+import torch.utils.data as utils_data
 from typing import Tuple
 from torchvision.transforms import Compose, ToTensor, Normalize
+import pandas as pd 
+import numpy as np
 
 
 def get_dataloaders(
-    cfg: DictConfig, num_workers: int = 4
-) -> Tuple[DataLoader, DataLoader]:
+    cfg: DictConfig, num_workers: int = 4,
+dataset_name: str = "mnist") -> Tuple[DataLoader, DataLoader]:
     """Return training and validation dataloaders"""
 
     ##################################################################
     # Change this. Demo dataset is MNIST
     ##################################################################
-    data_transform = Compose([ToTensor(), Normalize((0.1307,), (0.3081,))])
+    if dataset_name == "mnist":
+        data_transform = Compose([ToTensor(), Normalize((0.1307,), (0.3081,))])
 
-    dataset = torchvision.datasets.MNIST(
-        os.path.join(hydra.utils.get_original_cwd(), cfg.dirs.data),
-        download=True,
-        transform=data_transform,
-    )
+        dataset = torchvision.datasets.MNIST(
+            os.path.join(hydra.utils.get_original_cwd(), cfg.dirs.data),
+            download=True,
+            transform=data_transform,
+        )
 
-    train_dataloader = DataLoader(
-        dataset,
-        batch_size=cfg.mode.train.batch_size,
-        shuffle=cfg.mode.train.shuffle,
-        num_workers=num_workers,
-    )
+        train_dataloader = DataLoader(
+            dataset,
+            batch_size=cfg.mode.train.batch_size,
+            shuffle=cfg.mode.train.shuffle,
+            num_workers=num_workers,
+        )
 
-    val_dataloader = DataLoader(
-        dataset,
-        batch_size=cfg.mode.val.batch_size,
-        shuffle=cfg.mode.val.shuffle,
-        num_workers=num_workers,
-    )
+        val_dataloader = DataLoader(
+            dataset,
+            batch_size=cfg.mode.val.batch_size,
+            shuffle=cfg.mode.val.shuffle,
+            num_workers=num_workers,
+        )
+
+    elif dataset_name == "reunion":
+
+        (
+        list_of_training_inputs,
+        training_target_df,
+        list_of_testing_inputs,
+        testing_target_df,
+        ) = process_uni_data()
+
+        inputs_train = Variable(torch.FloatTensor(list_of_training_inputs))
+        targets_train = Variable(torch.FloatTensor(training_target_df))
+        inputs_test = Variable(torch.FloatTensor(list_of_testing_inputs))
+        targets_test = Variable(torch.FloatTensor(testing_target_df))
+
+        training_samples = utils_data.TensorDataset(inputs_train, targets_train)
+
+        train_dataloader = utils_data.DataLoader(
+            training_samples, batch_size=200, drop_last=False, shuffle=False
+        )
+
+        validation_samples = utils_data.TensorDataset(inputs_test, targets_test)
+
+        val_dataloader = utils_data.DataLoader(
+            validation_samples, batch_size=200, drop_last=False, shuffle=False
+        )
 
     return train_dataloader, val_dataloader
 
@@ -128,31 +160,5 @@ def process_uni_data():
         testing_target_df,
     )
 
-def get_dataloaders_regression(cfg, num_workers=1):
 
-    (
-        list_of_training_inputs,
-        training_target_df,
-        list_of_testing_inputs,
-        testing_target_df,
-    ) = process_uni_data()
-
-    inputs_train = Variable(torch.FloatTensor(list_of_training_inputs))
-    targets_train = Variable(torch.FloatTensor(training_target_df))
-    inputs_test = Variable(torch.FloatTensor(list_of_testing_inputs))
-    targets_test = Variable(torch.FloatTensor(testing_target_df))
-
-    training_samples = utils_data.TensorDataset(inputs_train, targets_train)
-
-    data_loader_trn = utils_data.DataLoader(
-        training_samples, batch_size=200, drop_last=False, shuffle=False
-    )
-
-    validation_samples = utils_data.TensorDataset(inputs_test, targets_test)
-
-    data_loader_val = utils_data.DataLoader(
-        validation_samples, batch_size=200, drop_last=False, shuffle=False
-    )
-
-    return data_loader_trn, data_loader_val
 

--- a/research/metrics/__init__.py
+++ b/research/metrics/__init__.py
@@ -1,0 +1,42 @@
+from ignite.metrics import Metric
+from ignite.exceptions import NotComputableError
+import torch
+import pdb
+import numpy as np
+
+# These decorators helps with distributed settings
+from ignite.metrics.metric import sync_all_reduce, reinit__is_reduced
+
+
+class Mape(Metric):
+    def __init__(self, output_transform=lambda x: x):
+
+        self._num_examples = None
+        self._sum_percentages = None
+        super(Mape, self).__init__(output_transform=output_transform)
+
+    @reinit__is_reduced
+    def reset(self):
+        self._num_examples = 0
+        self._sum_percentages = 0
+        super(Mape, self).reset()
+
+    @reinit__is_reduced
+    def update(self, output):
+        y_pred, y = output
+
+        errors = torch.abs(y_pred - y.view_as(y_pred))
+        errors_divided = errors / y.view_as(y_pred)
+
+
+        self._num_examples += torch.sum(y > 0.0).item()
+        self._sum_percentages += torch.sum(errors_divided[y > 0.0]).item()
+
+    @sync_all_reduce("_num_examples", "_sum_percentages")
+    def compute(self):
+        if self._num_examples == 0:
+            raise NotComputableError(
+                "CustomAccuracy must have at least one example before it can be computed."
+            )
+
+        return (self._sum_percentages / self._num_examples) * 100

--- a/research/metrics/__init__.py
+++ b/research/metrics/__init__.py
@@ -28,7 +28,6 @@ class Mape(Metric):
         errors = torch.abs(y_pred - y.view_as(y_pred))
         errors_divided = errors / y.view_as(y_pred)
 
-
         self._num_examples += torch.sum(y > 0.0).item()
         self._sum_percentages += torch.sum(errors_divided[y > 0.0]).item()
 

--- a/research/networks/__init__.py
+++ b/research/networks/__init__.py
@@ -24,23 +24,29 @@ class Net(nn.Module):
         return F.log_softmax(x, dim=-1)
 
 
+
 class MLP(nn.Module):
-    def __init__(self, input_size, hidden_size, hidden_size2, output_size, activation):
+    def __init__(self):
         super(MLP, self).__init__()
-        self.fc1 = nn.Linear(input_size, hidden_size)
-        self.dense1_bn = nn.BatchNorm1d(hidden_size)
-        self.fc2 = nn.Linear(hidden_size, hidden_size2)
-        self.dense2_bn = nn.BatchNorm1d(hidden_size2)
-        self.fc3 = nn.Linear(hidden_size2, output_size)
-        self.activation = activation
+        self.fc1 = nn.Linear(1008, 1000)
+        self.dense1_bn = nn.BatchNorm1d(1000)
+        self.fc2 = nn.Linear(1000, 500)
+        self.dense2_bn = nn.BatchNorm1d(500)
+        self.fc3 = nn.Linear(500, 144)
+        self.activation = 'relu'
 
     def forward(self, x):
-
-            theoutput = F.relu(self.fc1(x))
-            out = self.fc3(F.relu(self.fc2(theoutput))
+        theoutput = F.relu(self.fc1(x))
+        out = self.fc3(F.relu(self.fc2(theoutput)))
             
         return out
 
 # FIXME:
 def get_network(cfg: DictConfig) -> nn.Module:
-    return Net()
+
+    if cfg.example == "classification":
+        return Net()
+    elif cfg.example == "regression":
+        return MLP()
+    else:
+        print("Oops! It has to be either classification or regression for the demo")

--- a/research/networks/__init__.py
+++ b/research/networks/__init__.py
@@ -24,7 +24,6 @@ class Net(nn.Module):
         return F.log_softmax(x, dim=-1)
 
 
-
 class MLP(nn.Module):
     def __init__(self):
         super(MLP, self).__init__()
@@ -33,13 +32,14 @@ class MLP(nn.Module):
         self.fc2 = nn.Linear(1000, 500)
         self.dense2_bn = nn.BatchNorm1d(500)
         self.fc3 = nn.Linear(500, 144)
-        self.activation = 'relu'
+        self.activation = "relu"
 
     def forward(self, x):
         theoutput = F.relu(self.fc1(x))
         out = self.fc3(F.relu(self.fc2(theoutput)))
-            
+
         return out
+
 
 # FIXME:
 def get_network(cfg: DictConfig) -> nn.Module:

--- a/research/train.py
+++ b/research/train.py
@@ -30,7 +30,9 @@ def create_training_loop(
     model.to(device)
 
     # Optimizer
-    optimizer = torch.optim.SGD(model.parameters(), lr=cfg.learning_rate, momentum=0.8)
+    optimizer = torch.optim.SGD(
+        model.parameters(), lr=cfg.mode.train.learning_rate, momentum=0.8
+    )
 
     # Loss
     loss_fn = torch.nn.NLLLoss()
@@ -122,7 +124,7 @@ def create_regression_training_loop(
     model.to(device)
 
     # Optimizer
-    optimizer = torch.optim.SGD(model.parameters(), lr=cfg.learning_rate)
+    optimizer = torch.optim.SGD(model.parameters(), lr=cfg.mode.train.learning_rate)
 
     # Loss
     loss_fn = torch.nn.MSELoss()
@@ -156,7 +158,7 @@ def create_regression_training_loop(
         update_dict = {
             "loss": mse_val,
             "y_pred": y_pred * factor,
-            "ypred_first": [y_hat, y_pred_hat,],
+            "ypred_first": [y_hat, y_pred_hat],
             "y": y * factor,
         }
 
@@ -167,9 +169,7 @@ def create_regression_training_loop(
     # Required to set up logging
     engine.logger = setup_logger(name=name)
 
-    metrics = {
-        "mape": mape_metric,
-    }
+    metrics = {"mape": mape_metric}
 
     for name, metric in metrics.items():
         print("attaching metric:" + name)
@@ -179,7 +179,7 @@ def create_regression_training_loop(
 
 
 def create_regression_evaluation_loop(
-    model: nn.Module, cfg: DictConfig, name: str, device="cpu",
+    model: nn.Module, cfg: DictConfig, name: str, device="cpu"
 ) -> Engine:
 
     # Loss
@@ -317,7 +317,7 @@ def train(cfg: DictConfig) -> None:
                                 "x_label": "Iters",
                                 "y_label": "nll",
                             },
-                        ),
+                        )
                     ],
                 ),
             ],
@@ -409,7 +409,7 @@ def train(cfg: DictConfig) -> None:
             do_before_logging=postprocess_image_to_log,
             log_operations=[
                 (LOG_OP.SAVE_IMAGE, ["im"]),  # Save images to a folder
-                (LOG_OP.LOG_MESSAGE, ["nll"],),  # Log fields as message in logfile
+                (LOG_OP.LOG_MESSAGE, ["nll"]),  # Log fields as message in logfile
                 (
                     LOG_OP.SAVE_IN_DATA_FILE,
                     ["nll"],
@@ -429,7 +429,7 @@ def train(cfg: DictConfig) -> None:
                                 "fillarea": True,
                             },
                         ),
-                        VisPlot(var_name="nll_2", plot_key="p1", split="nll_2",),
+                        VisPlot(var_name="nll_2", plot_key="p1", split="nll_2"),
                     ],
                 ),
                 (
@@ -461,7 +461,7 @@ def train(cfg: DictConfig) -> None:
             log_operations=[
                 (
                     LOG_OP.LOG_MESSAGE,
-                    ["nll", "accuracy",],
+                    ["nll", "accuracy"],
                 ),  # Log fields as message in logfile
                 (
                     LOG_OP.SAVE_IN_DATA_FILE,

--- a/research/train.py
+++ b/research/train.py
@@ -1,14 +1,18 @@
 import logging
 import hydra
+import numpy as np
 import torch
 import torch.nn as nn
+import pdb
 
 from omegaconf import DictConfig
 from ignite.utils import setup_logger, manual_seed
+from ignite.handlers import Checkpoint, ModelCheckpoint, DiskSaver
 from ignite.engine import Events, Engine
 from ignite.metrics import Accuracy, Loss
 
 from dataset import get_dataloaders
+from metrics import Mape
 from networks import get_network
 from utils.log_operations import LOG_OP
 from utils.visdom_utils import VisPlot, VisImg
@@ -26,7 +30,7 @@ def create_training_loop(
     model.to(device)
 
     # Optimizer
-    optimizer = torch.optim.SGD(model.parameters(), lr=0.01, momentum=0.8)
+    optimizer = torch.optim.SGD(model.parameters(), lr=cfg.learning_rate, momentum=0.8)
 
     # Loss
     loss_fn = torch.nn.NLLLoss()
@@ -110,6 +114,131 @@ def create_evaluation_loop(
     return engine
 
 
+def create_regression_training_loop(
+    model: nn.Module, cfg: DictConfig, name: str, device="cpu"
+) -> Engine:
+
+    # Network
+    model.to(device)
+
+    # Optimizer
+    optimizer = torch.optim.SGD(model.parameters(), lr=cfg.learning_rate)
+
+    # Loss
+    loss_fn = torch.nn.MSELoss()
+
+    mape_metric = Mape(
+        output_transform=lambda infer_dict: (infer_dict["y_pred"], infer_dict["y"])
+    )
+
+    def _update(engine, batch):
+
+        model.train()
+
+        optimizer.zero_grad()
+        x, y = batch
+        x, y = x.to(device), y.to(device)
+
+        y_pred = model(x)
+
+        loss = loss_fn(10 * y_pred, 10 * y)
+
+        loss.backward()
+        optimizer.step()
+
+        factor = 1777.0
+
+        mse_val = loss_fn(factor * y_pred, factor * y).item()
+        y_hat = y[0].cpu().detach().numpy() * factor
+        y_pred_hat = y_pred[0].cpu().detach().numpy() * factor
+
+        # Anything you want to log must be returned in this dictionary
+        update_dict = {
+            "loss": mse_val,
+            "y_pred": y_pred * factor,
+            "ypred_first": [y_hat, y_pred_hat,],
+            "y": y * factor,
+        }
+
+        return update_dict
+
+    engine = Engine(_update)
+
+    # Required to set up logging
+    engine.logger = setup_logger(name=name)
+
+    metrics = {
+        "mape": mape_metric,
+    }
+
+    for name, metric in metrics.items():
+        print("attaching metric:" + name)
+        metric.attach(engine, name)
+
+    return engine
+
+
+def create_regression_evaluation_loop(
+    model: nn.Module, cfg: DictConfig, name: str, device="cpu",
+) -> Engine:
+
+    # Loss
+    loss_fn = torch.nn.MSELoss()
+
+    mape_metric = Mape(
+        output_transform=lambda infer_dict: (infer_dict["y_pred"], infer_dict["y"])
+    )
+
+    def _inference(engine, batch):
+
+        model.eval()
+
+        with torch.no_grad():
+
+            x, y = batch
+            x, y = x.to(device), y.to(device)
+            y_pred = model(x)
+
+            factor = 1777.0
+
+            y = y * factor
+            y_pred = y_pred * factor
+            mse_val = loss_fn(y, y_pred).item()
+
+        infer_dict = {
+            "loss": mse_val,
+            "y_pred": y_pred / factor,
+            "x": x / factor,
+            "y": y / factor,
+            "y_pred_times_factor": y_pred,
+            "y_times_factor": y,
+            "ypred_first": np.array([y[0], y_pred[0]]),
+        }
+
+        return infer_dict
+
+    engine = Engine(_inference)
+
+    engine.logger = setup_logger(name=name)
+
+    metrics = {
+        "loss": Loss(
+            loss_fn,
+            output_transform=lambda infer_dict: (
+                infer_dict["y_pred_times_factor"],
+                infer_dict["y_times_factor"],
+            ),
+        ),
+        "mape": mape_metric,
+    }
+
+    for name, metric in metrics.items():
+        print("attaching metric: " + name)
+        metric.attach(engine, name)
+
+    return engine
+
+
 def postprocess_image_to_log(state: Dict):
     """Sample function to show postprocessing done at log time """
     state.output["im"] = (
@@ -132,13 +261,24 @@ def train(cfg: DictConfig) -> None:
     model = get_network(cfg)
 
     # Data Loaders
-    train_loader, val_loader = get_dataloaders(cfg, num_workers=cfg.data_loader_workers)
-
-    # Your training loop
-    trainer = create_training_loop(model, cfg, "trainer", device=device)
-    # Your evaluation loop
-    evaluator = create_evaluation_loop(model, cfg, "evaluator", device=device)
-
+    if cfg.example == "classification":
+        train_loader, val_loader = get_dataloaders(
+            cfg, num_workers=cfg.data_loader_workers, dataset_name="mnist"
+        )
+        # Your training loop
+        trainer = create_training_loop(model, cfg, "trainer", device=device)
+        # Your evaluation loop
+        evaluator = create_evaluation_loop(model, cfg, "evaluator", device=device)
+    else:
+        train_loader, val_loader = get_dataloaders(
+            cfg, num_workers=cfg.data_loader_workers, dataset_name="reunion"
+        )
+        # Your training loop
+        trainer = create_regression_training_loop(model, cfg, "trainer", device=device)
+        # Your evaluation loop
+        evaluator = create_regression_evaluation_loop(
+            model, cfg, "evaluator", device=device
+        )
 
     ld = LogDirector(cfg, engines=[trainer, evaluator])
 
@@ -154,90 +294,212 @@ def train(cfg: DictConfig) -> None:
         evaluator.run(val_loader)
         return evaluator  # NOTE: Must return the engine we want to log from
 
-    ld.set_event_handlers(
-        trainer,
-        Events.ITERATION_COMPLETED(every=50),
-        EngineStateAttr.OUTPUT,
-        do_before_logging=postprocess_image_to_log,
-        log_operations=[
-            (LOG_OP.SAVE_IMAGE, ["im"]),  # Save images to a folder
-            (LOG_OP.LOG_MESSAGE, ["nll"]),  # Log fields as message in logfile
-            (LOG_OP.SAVE_IN_DATA_FILE, ["nll"]),  # Log fields as separate data files
-            (
-                LOG_OP.NUMBER_TO_VISDOM,
-                [
-                    # First plot, key is "p1"
-                    VisPlot(
-                        var_name="nll",
-                        plot_key="p1",
-                        split="nll_1",
-                        # Any opts that Visdom supports
-                        opts={"title": "Plot 1", "xlabel": "Iters", "fillarea": True},
-                    ),
-                    VisPlot(var_name="nll_2", plot_key="p1", split="nll_2"),
-                ],
-            ),
-            (
-                LOG_OP.IMAGE_TO_VISDOM,
-                [
-                    VisImg(
-                        var_name="im",
-                        img_key="1",
-                        env="images",
-                        opts={"caption": "a current image", "title": "title"},
-                    ),
-                    VisImg(
-                        var_name="im",
-                        img_key="2",
-                        env="images",
-                        opts={"caption": "a current image", "title": "title"},
-                    ),
-                ],
-            ),
-        ],
-    )
+    if cfg.example == "regression":
 
-    ld.set_event_handlers(
-        trainer,
-        Events.EPOCH_COMPLETED,
-        EngineStateAttr.METRICS,
-        # Run the evaluation loop, then do log operations from the return engine
-        engine_producer=run_evaluator,
-        log_operations=[
-            (
-                LOG_OP.LOG_MESSAGE,
-                ["nll", "accuracy"],
-            ),  # Log fields as message in logfile
-            (
-                LOG_OP.SAVE_IN_DATA_FILE,
-                ["accuracy"],
-            ),  # Log fields as separate data files
-            (
-                LOG_OP.NUMBER_TO_VISDOM,
-                [
-                    # First plot, key is "p1"
-                    VisPlot(
-                        var_name="accuracy",
-                        plot_key="p3",
-                        split="acc",
-                        # Any opts that Visdom supports
-                        opts={"title": "Eval Acc", "xlabel": "Iters"},
-                    ),
-                    # First plot, key is "p1"
-                    VisPlot(
-                        var_name="nll",
-                        plot_key="p4",
-                        split="nll",
-                        # Any opts that Visdom supports
-                        opts={"title": "Eval Nll", "xlabel": "Iters", "fillarea": True},
-                    ),
-                ],
-            ),
-        ],
-    )
+        ld.set_event_handlers(
+            trainer,
+            Events.EPOCH_COMPLETED(every=1),
+            EngineStateAttr.OUTPUT,
+            log_operations=[
+                (LOG_OP.LOG_MESSAGE, ["loss"]),
+                (LOG_OP.SAVE_IN_DATA_FILE, ["loss"]),
+                (
+                    LOG_OP.NUMBER_TO_VISDOM,
+                    [
+                        # First plot, key is "p1"
+                        VisPlot(
+                            var_name="loss",
+                            plot_key="p1",
+                            split="mse",
+                            env="main",
+                            opts={
+                                "title": "Train error (loss) ",
+                                "x_label": "Iters",
+                                "y_label": "nll",
+                            },
+                        ),
+                    ],
+                ),
+            ],
+        )
+
+        ld.set_event_handlers(
+            trainer,
+            Events.EPOCH_COMPLETED(every=20),
+            EngineStateAttr.METRICS,
+            engine_producer=run_evaluator,
+            log_operations=[
+                (
+                    LOG_OP.NUMBER_TO_VISDOM,
+                    [
+                        # First plot, key is "p1"
+                        VisPlot(
+                            var_name="loss",
+                            plot_key="p2",
+                            split="mse",
+                            opts={
+                                "title": "Eval error (loss)",
+                                "x_label": "Epoch",
+                                "y_label": "Loss",
+                            },
+                            env="main",
+                        )
+                    ],
+                ),
+                (
+                    LOG_OP.NUMBER_TO_VISDOM,
+                    [
+                        VisPlot(
+                            var_name="mape",
+                            plot_key="p3",
+                            split="MAPE",
+                            opts={
+                                "title": "Eval error (MAPE)",
+                                "x_label": "Epoch",
+                                "y_label": "MAPE",
+                            },
+                            env="main",
+                        )
+                    ],
+                ),
+            ],
+        )
+
+        def score_function(engine):
+            return evaluator.state.metrics["mape"]
+
+        handler = ModelCheckpoint(
+            "models/", "checkpoint", score_function=score_function, n_saved=5
+        )
+
+        trainer.add_event_handler(
+            Events.EPOCH_COMPLETED(every=50), handler, {"mlp": model}
+        )
+
+        ld.set_event_handlers(
+            trainer,
+            Events.EPOCH_COMPLETED(every=100),
+            EngineStateAttr.OUTPUT,
+            engine_producer=run_evaluator,
+            log_operations=[
+                (
+                    LOG_OP.VECTOR_TO_VISDOM,
+                    [
+                        VisPlot(
+                            var_name="ypred_first",
+                            plot_key="e",
+                            split="nll",
+                            opts={
+                                "title": "Predictions vs. Ground Truth,  # ",
+                                "x_label": "Time",
+                                "y_label": "Energy Consumption",
+                            },
+                            env="main",
+                        )
+                    ],
+                )
+            ],
+        )
+
+    if cfg.example == "classification":
+        ld.set_event_handlers(
+            trainer,
+            Events.ITERATION_COMPLETED(every=50),
+            EngineStateAttr.OUTPUT,
+            do_before_logging=postprocess_image_to_log,
+            log_operations=[
+                (LOG_OP.SAVE_IMAGE, ["im"]),  # Save images to a folder
+                (LOG_OP.LOG_MESSAGE, ["nll"],),  # Log fields as message in logfile
+                (
+                    LOG_OP.SAVE_IN_DATA_FILE,
+                    ["nll"],
+                ),  # Log fields as separate data files
+                (
+                    LOG_OP.NUMBER_TO_VISDOM,
+                    [
+                        # First plot, key is "p1"
+                        VisPlot(
+                            var_name="nll",
+                            plot_key="p1",
+                            split="nll_1",
+                            # Any opts that Visdom supports
+                            opts={
+                                "title": "Plot 1",
+                                "xlabel": "Iters",
+                                "fillarea": True,
+                            },
+                        ),
+                        VisPlot(var_name="nll_2", plot_key="p1", split="nll_2",),
+                    ],
+                ),
+                (
+                    LOG_OP.IMAGE_TO_VISDOM,
+                    [
+                        VisImg(
+                            var_name="im",
+                            img_key="1",
+                            env="images",
+                            opts={"caption": "a current image", "title": "title"},
+                        ),
+                        VisImg(
+                            var_name="im",
+                            img_key="2",
+                            env="images",
+                            opts={"caption": "a current image", "title": "title"},
+                        ),
+                    ],
+                ),
+            ],
+        )
+
+        ld.set_event_handlers(
+            trainer,
+            Events.EPOCH_COMPLETED,
+            EngineStateAttr.METRICS,
+            # Run the evaluation loop, then do log operations from the return engine
+            engine_producer=run_evaluator,
+            log_operations=[
+                (
+                    LOG_OP.LOG_MESSAGE,
+                    ["nll", "accuracy",],
+                ),  # Log fields as message in logfile
+                (
+                    LOG_OP.SAVE_IN_DATA_FILE,
+                    ["accuracy"],
+                ),  # Log fields as separate data files
+                (
+                    LOG_OP.NUMBER_TO_VISDOM,
+                    [
+                        # First plot, key is "p1"
+                        VisPlot(
+                            var_name="accuracy",
+                            plot_key="p3",
+                            split="acc",
+                            # Any opts that Visdom supports
+                            opts={"title": "Eval Acc", "xlabel": "Iters"},
+                        ),
+                        # First plot, key is "p1"
+                        VisPlot(
+                            var_name="nll",
+                            plot_key="p4",
+                            split="nll",
+                            # Any opts that Visdom supports
+                            opts={
+                                "title": "Eval Nll",
+                                "xlabel": "Iters",
+                                "fillarea": True,
+                            },
+                        ),
+                    ],
+                ),
+            ],
+        )
 
     # Execute training
-    trainer.run(train_loader, max_epochs=cfg.mode.train.max_epochs)
+    if cfg.example == "regression":
+        trainer.run(train_loader, max_epochs=1000)
+    else:
+        trainer.run(train_loader, max_epochs=cfg.mode.train.max_epochs)
 
 
 if __name__ == "__main__":

--- a/research/utils/LogDirector.py
+++ b/research/utils/LogDirector.py
@@ -99,6 +99,7 @@ class LogDirector:
                 if (
                     log_op is LOG_OP.NUMBER_TO_VISDOM
                     or log_op is LOG_OP.IMAGE_TO_VISDOM
+                    or log_op is LOG_OP.VECTOR_TO_VISDOM
                 ):
                     visdom_log_op = log_op
                     visdom_log_op(

--- a/research/utils/log_operations.py
+++ b/research/utils/log_operations.py
@@ -125,7 +125,7 @@ def _vector_to_visdom(
 
         if x_value is None:
 
-            if len(value_dict[msg.var_name]) > 1: 
+            if len(value_dict[msg.var_name]) > 1:
                 x_value = np.arange(len(value_dict[msg.var_name][0]))
             else:
                 x_value = np.arange(len(value_dict[msg.var_name]))
@@ -145,7 +145,7 @@ def _image_to_visdom(
     vis: Visualizer,
     vis_img_msgs: List[VisImg],
     engine_attr: str,
-    **kwargs
+    **kwargs,
 ) -> None:
     """Log image engine output to Visdom server"""
     for msg in vis_img_msgs:

--- a/research/utils/log_operations.py
+++ b/research/utils/log_operations.py
@@ -2,6 +2,7 @@ import logging
 import struct
 import os
 import torch
+import pdb
 
 import numpy as np
 
@@ -107,7 +108,7 @@ def _number_to_visdom(
             opts=msg.opts,
         )
 
-"""
+
 def _vector_to_visdom(
     engine: Engine,
     vis: Visualizer,
@@ -120,11 +121,14 @@ def _vector_to_visdom(
     """Save engine output to Visdom server"""
     value_dict = getattr(engine.state, engine_attr)
 
-    if x_value is None:
-
-        x_value = np.arange(len(value_dict[msg.var_name]))
-
     for msg in vis_plot_msgs:
+
+        if x_value is None:
+
+            if len(value_dict[msg.var_name]) > 1: 
+                x_value = np.arange(len(value_dict[msg.var_name][0]))
+            else:
+                x_value = np.arange(len(value_dict[msg.var_name]))
 
         vis.plot_line(
             msg.plot_key,
@@ -133,7 +137,7 @@ def _vector_to_visdom(
             value_dict[msg.var_name],
             env=msg.env,
             opts=msg.opts,
-        )"""
+        )
 
 
 def _image_to_visdom(
@@ -166,5 +170,7 @@ class LOG_OP(Enum):
     SAVE_IMAGE = _to_file_img
     # Log to visdom
     NUMBER_TO_VISDOM = _number_to_visdom
+    # Log vector to visdom
+    VECTOR_TO_VISDOM = _vector_to_visdom
     # Log image to visdom
     IMAGE_TO_VISDOM = _image_to_visdom

--- a/research/utils/visdom_utils.py
+++ b/research/utils/visdom_utils.py
@@ -12,7 +12,7 @@ from omegaconf import DictConfig
 from visdom import server, Visdom
 
 
-#matplotlib.use("tkagg")
+# matplotlib.use("tkagg")
 
 
 @hydra.main(config_path="../configs", config_name="default.yaml")
@@ -117,7 +117,7 @@ class Visualizer:
                 X=np.array([x, x]),
                 Y=np.array([y, y]),
                 env=env,
-                opts={**opts,"legend": [split_name]},
+                opts={**opts, "legend": [split_name]},
             )
         else:
             self.vis.line(
@@ -128,7 +128,6 @@ class Visualizer:
                 name=split_name,
                 update="append",
             )
-
 
     def plot_line(
         self,
@@ -145,11 +144,11 @@ class Visualizer:
             plot_key = "e" + str(self.counter)
             self.counter = self.counter + 1
             if self.counter == 1:
-                opts["title"] = opts["title"]  + str(self.counter)  
-            elif self.counter > 10 :
-                opts["title"] = opts["title"][:-2]  + str(self.counter)
+                opts["title"] = opts["title"] + str(self.counter)
+            elif self.counter > 10:
+                opts["title"] = opts["title"][:-2] + str(self.counter)
             else:
-                opts["title"] = opts["title"][:-1]  + str(self.counter)
+                opts["title"] = opts["title"][:-1] + str(self.counter)
 
         if plot_key not in self.plots:
 
@@ -157,7 +156,7 @@ class Visualizer:
                 for i in range(y.shape[0]):
                     if i == 0:
                         self.plots[plot_key] = self.vis.line(
-                            X=x, Y=y[i], env=env, opts={**opts},
+                            X=x, Y=y[i], env=env, opts={**opts}
                         )
                     else:
                         self.vis.line(
@@ -171,7 +170,7 @@ class Visualizer:
 
             elif y.shape[0] == 1:
                 self.plots[plot_key] = self.vis.line(
-                    X=x, Y=y, env=env, opts={**opts, "legend": [split_name]},
+                    X=x, Y=y, env=env, opts={**opts, "legend": [split_name]}
                 )
             else:
                 print(
@@ -183,7 +182,7 @@ class Visualizer:
                 for i in range(y.shape[0]):
                     if i == 0:
                         win = self.vis.line(
-                            X=x, Y=y[i], env=env, opts={**opts, "legend": [split_name]},
+                            X=x, Y=y[i], env=env, opts={**opts, "legend": [split_name]}
                         )
                     else:
                         self.vis.line(
@@ -196,7 +195,7 @@ class Visualizer:
                         )
             elif y.shape[0] == 1:
                 win = self.vis.line(
-                    X=x, Y=y, env=env, opts={**opts, "legend": [split_name]},
+                    X=x, Y=y, env=env, opts={**opts, "legend": [split_name]}
                 )
             else:
                 print(

--- a/research/utils/visdom_utils.py
+++ b/research/utils/visdom_utils.py
@@ -117,7 +117,7 @@ class Visualizer:
                 X=np.array([x, x]),
                 Y=np.array([y, y]),
                 env=env,
-                opts={**opts, "legend": [split_name]},
+                opts={**opts,"legend": [split_name]},
             )
         else:
             self.vis.line(
@@ -129,7 +129,7 @@ class Visualizer:
                 update="append",
             )
 
-"""
+
     def plot_line(
         self,
         plot_key: str,
@@ -139,12 +139,17 @@ class Visualizer:
         env: str = None,
         opts: Dict = None,
     ):
-        """Visdom plot line data. e denotes the option to have a new 
-        window for every time you call plot_line"""
+        """Visdom plot line data"""
 
         if plot_key == "e":
             plot_key = "e" + str(self.counter)
             self.counter = self.counter + 1
+            if self.counter == 1:
+                opts["title"] = opts["title"]  + str(self.counter)  
+            elif self.counter > 10 :
+                opts["title"] = opts["title"][:-2]  + str(self.counter)
+            else:
+                opts["title"] = opts["title"][:-1]  + str(self.counter)
 
         if plot_key not in self.plots:
 
@@ -172,7 +177,6 @@ class Visualizer:
                 print(
                     "Error: you are not supposed to have more than 3 dimensions here."
                 )
-
         else:
 
             if y.shape[0] == 2:
@@ -197,7 +201,8 @@ class Visualizer:
             else:
                 print(
                     "Error: you are not supposed to have more than 3 dimensions here."
-                )"""
+                )
+
 
 if __name__ == "__main__":
     make_visdom()

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ REQUIRED = [
     "torch>=1.5.0",
     "pytorch-ignite>=0.3.0",
     "torchvision>=0.6.0",
+    "pandas>=1.1.0",
 ]
 
 # What packages are optional?


### PR DESCRIPTION
…s feature

In order to checkout the regression example, run : python train.py example=regression -m . The results will plot in "main". 

Things left to be done: 

-extend the "multiple line plots in one plot" feature to number_to_visdom
-option to pass in x_value 
-option to make a scatter plot 
-figure out the path to the data so that it works regardless of whether you use -m or not. 

The reason I waited for the x_value + scatter_plot thing is that I think it would make more sense for the vision community to see an example of a scatter updating in during training for a distribution. for example, how well normalizing flows captures a distribution over time. There is some good code for this here (https://github.com/tonyduan/normalizing-flows/blob/master/examples/flow_2d.py) but I am now tired and will not do it today lol. Also, I will do the path thing tomorrow morning, but for now test it with the "-m" flag. 